### PR TITLE
Fix crash on macOS when launching TACL a second time + fix dark theme support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ __pycache__/
 
 /env/
 /download/current
+
+# macOS specific files
+.DS_Store

--- a/src/app/views/components/DatabaseInfoGroupBox.py
+++ b/src/app/views/components/DatabaseInfoGroupBox.py
@@ -52,7 +52,7 @@ class DatabaseInfoGroupBox(QGroupBox):
 
     def _createValueLabel(self) -> QLabel:
         label = QLabel()
-        label.setStyleSheet("background-color: #ffffff; padding: 5px;")
+        label.setStyleSheet("border: 1.5px solid #D3D3D3; padding: 5px;")
         label.setTextInteractionFlags(Qt.TextSelectableByMouse )
 
         return label

--- a/src/app/views/components/DatabaseInfoGroupBox.py
+++ b/src/app/views/components/DatabaseInfoGroupBox.py
@@ -52,7 +52,7 @@ class DatabaseInfoGroupBox(QGroupBox):
 
     def _createValueLabel(self) -> QLabel:
         label = QLabel()
-        label.setStyleSheet("border: 1.5px solid #D3D3D3; padding: 5px;")
+        label.setStyleSheet("background-color: #ffffff; color: #000000; padding: 5px;")
         label.setTextInteractionFlags(Qt.TextSelectableByMouse )
 
         return label

--- a/src/main.py
+++ b/src/main.py
@@ -28,11 +28,13 @@ if __name__ == '__main__':
     # Determine the base path
 
     if sys.platform == 'darwin':
+        # On macOS: Use "~/Library/Application Support/TACL" instead of the current working directory to comply with macOS Sandbox restrictions
         from AppKit import NSSearchPathForDirectoriesInDomains, NSApplicationSupportDirectory, NSUserDomainMask
         # http://developer.apple.com/DOCUMENTATION/Cocoa/Reference/Foundation/Miscellaneous/Foundation_Functions/Reference/reference.html#//apple_ref/c/func/NSSearchPathForDirectoriesInDomains
         # Last parameter 'True' for expanding the tilde into a fully qualified path
         baseDir = os.path.join(NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, True)[0], "TACL")
-        os.makedirs(baseDir, exist_ok=False)
+        # Create the directory if it does not exist yet
+        os.makedirs(baseDir, exist_ok=True)
     elif getattr(sys, 'frozen', False) and sys.executable:
         baseDir = os.path.dirname(sys.executable)
     else:


### PR DESCRIPTION
## Issue 1

Apparently I set the `exist_ok` flag for makedirs incorrectly, which leads to TACL-GUI crashing on macOS when launched a second time (since the directory already exists):
<img width="372" alt="Screenshot 2022-08-24 at 14 16 58" src="https://user-images.githubusercontent.com/1589939/186387142-f955c3b5-0fa5-47b4-acde-36a19ddbb040.png">

## Issue 2

In addition, we noticed that the labels in the "Database Info" component become unreadable when setting the system theme to "dark" (I highlighted the database path by selecting it with the cursor):
<img width="485" alt="Screenshot 2022-08-12 at 14 40 54" src="https://user-images.githubusercontent.com/1589939/186396716-592edeb2-82d6-4015-8231-704d22a16952.png">

I suspect that the same issue shows on other OS' with dark themes, like Windows or Ubuntu. To resolve this quickly, I changed the label styling from setting a white background color to setting a border. But please feel free to implement a different solution!

<img width="520" alt="Screenshot 2022-08-24 at 17 37 50" src="https://user-images.githubusercontent.com/1589939/186387935-bd7e39b5-1e47-4410-b51c-079a4a89fb0b.png">

<img width="476" alt="Screenshot 2022-08-24 at 17 37 55" src="https://user-images.githubusercontent.com/1589939/186387940-9280aad4-a8fe-4a8c-ba7b-0d2e89f309d2.png">

I uploaded the ZIP-archive with the updated macOS build based on this PR again to my Dropbox: https://www.dropbox.com/s/gmc6uvvtayowbfh/TACL-GUI.Darwin.zip?dl=0